### PR TITLE
Create release CI workflow

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,77 @@
+name: Bump version number
+
+on:
+  workflow_dispatch:
+    inputs:
+      version-component:
+        type: choice
+        default: 'patch'
+        required: true
+        options:
+          - 'major'
+          - 'minor'
+          - 'patch'
+
+jobs:
+
+  bump:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          # here we need v3.10+
+          python-version: 3.x
+
+      - run: pip install toml
+      - name: increment version
+        id: inc-ver
+        shell: python
+        run: |-
+          from os import environ
+          from pathlib import Path
+          from typing import cast, Dict
+          import toml
+
+          COMPONENTS = ["major", "minor", "patch"]
+
+          cargo_file = Path("Cargo.toml")
+          assert cargo_file.exists()
+          data = cast(
+              Dict[str, Dict[str, str]],
+              toml.loads(cargo_file.read_text(encoding="utf-8")),
+          )
+          assert "package" in data
+          assert "version" in data["package"]
+          old_version = data["package"]["version"]
+          print("Current version:", old_version)
+          new_ver = [int(x) for x in old_version.split(".")]
+          component = COMPONENTS.index("${{ inputs.version-component }}")
+          new_ver[component] += 1
+          # zero out minor and patch components if needed
+          for i in range(component + 1, len(COMPONENTS)):
+              new_ver[i] = 0
+          new_version = ".".join([str(x) for x in new_ver])
+          data["package"]["version"] = new_version
+          print("New version:", new_version)
+          cargo_file.write_text(toml.dumps(data), encoding="utf-8", newline="\n")
+
+          # create an output variables for use in CI workflow
+          if "GITHUB_OUTPUT" in environ:
+              with open(environ["GITHUB_OUTPUT"], mode="a") as gh_out:
+                  gh_out.write(f"new-version={new_version}\n")
+
+      - run: cargo update
+
+      - name: Push metadata changes and tag
+        run: |-
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git add --all
+          git commit -m "bump version to v${{ steps.inc-ver.outputs.new-version }}"
+          git push
+          git tag v${{ steps.inc-ver.outputs.new-version }}
+          git push origin v${{ steps.inc-ver.outputs.new-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - v[0-9]+.*
+  pull_request:
+    branches: [main]
+
+jobs:
+
+  build:
+    name: Build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - name: Calculate Release Version
+        id: calc-version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            short_sha=$(echo "${{ github.sha }}" | awk '{print substr($0,0,5)}')
+            echo "RELEASE_VERSION=nightly-$(date '+%Y-%m-%d')-$short_sha" >> $GITHUB_OUTPUT
+          else
+            echo "RELEASE_VERSION=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.target }}
+
+      - name: install cross
+        if: contains(matrix.target, 'aarch64') && matrix.os == 'ubuntu-latest'
+        uses: taiki-e/install-action@cross
+
+      - name: Install musl-tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt install -y musl-tools
+
+      - name: Build
+        if: ${{ !(contains(matrix.target, 'aarch64') && matrix.os == 'ubuntu-latest') }}
+        run: cargo build --release --bin mdbook-alerts --target ${{ matrix.target }}
+
+      - name: Build with cross
+        if: contains(matrix.target, 'aarch64') && matrix.os == 'ubuntu-latest'
+        run: cross build --release --bin mdbook-alerts --target ${{ matrix.target }}
+
+      - name: Prepare artifacts [Windows]
+        shell: bash
+        if: matrix.os == 'windows-latest'
+        id: prep-artifacts-windows
+        run: |
+          release_dir="mdbook-alerts_${{ steps.calc-version.outputs.RELEASE_VERSION }}"
+          artifact_path="mdbook-alerts_${{ steps.calc-version.outputs.RELEASE_VERSION }}-${{ matrix.target }}.zip"
+          echo "ARTIFACT_NAME=$release_dir-${{ matrix.target }}" >> $GITHUB_OUTPUT
+          echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_OUTPUT
+          mkdir $release_dir
+          cp target/${{ matrix.target }}/release/mdbook-alerts.exe $release_dir/
+          cp LICENSE $release_dir/
+          7z a -tzip $artifact_path $release_dir/
+
+      - name: Prepare artifacts [Unix]
+        shell: bash
+        id: prep-artifacts-unix
+        if: matrix.os != 'windows-latest'
+        run: |
+          release_dir="mdbook-alerts_${{ steps.calc-version.outputs.RELEASE_VERSION }}"
+          artifact_path="mdbook-alerts_${{ steps.calc-version.outputs.RELEASE_VERSION }}-${{ matrix.target }}.tar.gz"
+          echo "ARTIFACT_NAME=$release_dir-${{ matrix.target }}" >> $GITHUB_OUTPUT
+          echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_OUTPUT
+          mkdir $release_dir
+          cp target/${{ matrix.target }}/release/mdbook-alerts $release_dir/
+          cp LICENSE $release_dir
+          tar -czvf $artifact_path $release_dir/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.prep-artifacts-unix.outputs.ARTIFACT_NAME || steps.prep-artifacts-windows.outputs.ARTIFACT_NAME }}
+          path: ${{ steps.prep-artifacts-unix.outputs.ARTIFACT_PATH || steps.prep-artifacts-windows.outputs.ARTIFACT_PATH }}
+          if-no-files-found: error
+
+  release:
+    if: startswith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: rustup update stable --no-self-update
+      - run: cargo publish
+        if: github.repository == 'lambdalisue/rs-mdbook-alerts'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Download build assets
+        uses: actions/download-artifact@v4
+        with:
+          pattern: mdbook-alerts_*
+          path: dist
+      - name: Create a Github Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(ls dist/mdbook-alerts_*/*{tar.gz,zip})
+          gh release create ${{ github.ref_name }} --generate-notes $files


### PR DESCRIPTION
resolves #48 

I have tested this on my fork to ensure the Github releases are created correctly with the built binary files attached.

As promised, this new CI workflow will
1. build the binary on several targets
2. cache the built binaries as CI artifacts
3. create a GitHub release using [`gh-cli`](https://cli.github.com/manual/gh_release) and upload the cached CI artifacts as release assets
4. publish to crates.io [using a secret variable](https://github.com/lambdalisue/rs-mdbook-alerts/settings/secrets/actions) (named `CARGO_REGISTRY_TOKEN`) containing the [auth token for your account at crates.io](https://crates.io/settings/tokens)

This CI is triggered on
- any push to main
- any PR changes targeting the main branch
- any tag pushed to main that begins with `v[0-9]`. This event is the only event that will create a release and publish to crates.io; all other events only build the binaries and save them as CI artifacts.

> [!tip]
> This new workflow could technically replace the existing build.yml workflow. I did not remove the build.yml though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a workflow to automate the build and release process, including building artifacts for various platforms and publishing to the Rust registry.
  - Added a GitHub Actions workflow to automate version bumping (major, minor, or patch) for the project, updating the `Cargo.toml`, and committing the changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->