### PR TITLE
Fix rendering result on CRLF content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +369,12 @@ dependencies = [
  "serde_derive",
  "serde_json",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
@@ -897,6 +915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +938,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
 ]
 
 [[package]]
@@ -1072,6 +1107,8 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "indoc",
+ "insta",
  "mdbook",
  "once_cell",
  "regex",
@@ -1671,6 +1708,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ rust-embed = "8.5.0"
 semver = "1.0.26"
 serde = { version = "1.0.217", features = ["serde_derive"] }
 serde_json = "1.0.140"
+
+[dev-dependencies]
+indoc = "2.0.6"
+insta = "1.43.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ fn render_alerts(content: &str) -> Result<String, Error> {
     });
     let alerts = Asset::get("alerts.tmpl").expect("alerts.tmpl not found in assets");
     let alerts = std::str::from_utf8(alerts.data.as_ref())?;
+    let newline = find_newline(content);
+    let content = content.replace(&newline, "\n");
+    let content = content.as_str();
     let content = RE.replace_all(content, |caps: &regex::Captures| {
         let kind = caps
             .name("kind")
@@ -69,7 +72,18 @@ fn render_alerts(content: &str) -> Result<String, Error> {
             .replace("\n> ", "\n");
         alerts.replace("{kind}", &kind).replace("{body}", &body)
     });
-    Ok(content.into())
+    Ok(content.replace("\n", newline))
+}
+
+fn find_newline(content: &str) -> &'static str {
+    let mut cr = 0;
+    let mut lf = 0;
+    content.chars().for_each(|c| match c {
+        '\r' => cr += 1,
+        '\n' => lf += 1,
+        _ => {}
+    });
+    return if cr == lf { "\r\n" } else { "\n" };
 }
 
 #[cfg(test)]
@@ -163,8 +177,27 @@ mod tests {
 
         This should be a paragraph.
         "#};
-
         let result = render_alerts(content).unwrap();
+        assert_debug_snapshot!(result);
+        assert_snapshot!(result);
+    }
+
+    #[test]
+    fn test_render_alerts_with_crlf() {
+        let content = indoc! {r#"
+        This should be a paragraph.
+
+        > This should be a blockquote.
+        > This should be in a previous blockquote.
+
+        > [!NOTE]
+        > This should be alert.
+        > This should be in a previous alert.
+
+        This should be a paragraph.
+        "#};
+        let content = content.replace("\n", "\r\n");
+        let result = render_alerts(content.as_str()).unwrap();
         assert_debug_snapshot!(result);
         assert_snapshot!(result);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ fn render_alerts(content: &str) -> Result<String, Error> {
     });
     let alerts = Asset::get("alerts.tmpl").expect("alerts.tmpl not found in assets");
     let alerts = std::str::from_utf8(alerts.data.as_ref())?;
+    let alerts = alerts.replace("\r\n", "\n");
     let newline = find_newline(content);
     let content = content.replace(&newline, "\n");
     let content = content.as_str();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,13 @@ fn render_alerts(content: &str) -> Result<String, Error> {
     });
     Ok(content.into())
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
+    use insta::assert_debug_snapshot;
+    use insta::assert_snapshot;
 
     #[test]
     fn test_inject_stylesheet_includes_css() {
@@ -93,17 +97,18 @@ mod tests {
         assert!(output.contains("This is a note."));
         assert_eq!(
             output,
-            r#"<div class="mdbook-alerts mdbook-alerts-note">
-<p class="mdbook-alerts-title">
-  <span class="mdbook-alerts-icon"></span>
-  note
-</p>
-
-
-This is a note.
-
-</div>
-"#
+            indoc! {r#"
+            <div class="mdbook-alerts mdbook-alerts-note">
+            <p class="mdbook-alerts-title">
+              <span class="mdbook-alerts-icon"></span>
+              note
+            </p>
+            
+            
+            This is a note.
+            
+            </div>
+            "#}
         );
     }
 
@@ -117,29 +122,50 @@ This is a note.
         assert!(output.contains("Tip 2."));
         assert_eq!(
             output,
-            r#"<div class="mdbook-alerts mdbook-alerts-warning">
-<p class="mdbook-alerts-title">
-  <span class="mdbook-alerts-icon"></span>
-  warning
-</p>
+            indoc! {r#"
+            <div class="mdbook-alerts mdbook-alerts-warning">
+            <p class="mdbook-alerts-title">
+              <span class="mdbook-alerts-icon"></span>
+              warning
+            </p>
 
 
-Warning 1.
+            Warning 1.
 
-</div>
-
-
-<div class="mdbook-alerts mdbook-alerts-tip">
-<p class="mdbook-alerts-title">
-  <span class="mdbook-alerts-icon"></span>
-  tip
-</p>
+            </div>
 
 
-Tip 2.
+            <div class="mdbook-alerts mdbook-alerts-tip">
+            <p class="mdbook-alerts-title">
+              <span class="mdbook-alerts-icon"></span>
+              tip
+            </p>
 
-</div>
-"#
+
+            Tip 2.
+
+            </div>
+            "#}
         );
+    }
+
+    #[test]
+    fn test_render_alerts() {
+        let content = indoc! {r#"
+        This should be a paragraph.
+
+        > This should be a blockquote.
+        > This should be in a previous blockquote.
+
+        > [!NOTE]
+        > This should be alert.
+        > This should be in a previous alert.
+
+        This should be a paragraph.
+        "#};
+
+        let result = render_alerts(content).unwrap();
+        assert_debug_snapshot!(result);
+        assert_snapshot!(result);
     }
 }

--- a/src/snapshots/mdbook_alerts__tests__render_alerts-2.snap
+++ b/src/snapshots/mdbook_alerts__tests__render_alerts-2.snap
@@ -1,0 +1,23 @@
+---
+source: src/lib.rs
+expression: result
+---
+This should be a paragraph.
+
+> This should be a blockquote.
+> This should be in a previous blockquote.
+
+<div class="mdbook-alerts mdbook-alerts-note">
+<p class="mdbook-alerts-title">
+  <span class="mdbook-alerts-icon"></span>
+  note
+</p>
+
+
+This should be alert.
+This should be in a previous alert.
+
+</div>
+
+
+This should be a paragraph.

--- a/src/snapshots/mdbook_alerts__tests__render_alerts.snap
+++ b/src/snapshots/mdbook_alerts__tests__render_alerts.snap
@@ -1,0 +1,5 @@
+---
+source: src/lib.rs
+expression: result
+---
+"This should be a paragraph.\n\n> This should be a blockquote.\n> This should be in a previous blockquote.\n\n<div class=\"mdbook-alerts mdbook-alerts-note\">\n<p class=\"mdbook-alerts-title\">\n  <span class=\"mdbook-alerts-icon\"></span>\n  note\n</p>\n\n\nThis should be alert.\nThis should be in a previous alert.\n\n</div>\n\n\nThis should be a paragraph.\n"

--- a/src/snapshots/mdbook_alerts__tests__render_alerts_with_crlf-2.snap
+++ b/src/snapshots/mdbook_alerts__tests__render_alerts_with_crlf-2.snap
@@ -1,0 +1,23 @@
+---
+source: src/lib.rs
+expression: result
+---
+This should be a paragraph.
+
+> This should be a blockquote.
+> This should be in a previous blockquote.
+
+<div class="mdbook-alerts mdbook-alerts-note">
+<p class="mdbook-alerts-title">
+  <span class="mdbook-alerts-icon"></span>
+  note
+</p>
+
+
+This should be alert.
+This should be in a previous alert.
+
+</div>
+
+
+This should be a paragraph.

--- a/src/snapshots/mdbook_alerts__tests__render_alerts_with_crlf.snap
+++ b/src/snapshots/mdbook_alerts__tests__render_alerts_with_crlf.snap
@@ -1,0 +1,5 @@
+---
+source: src/lib.rs
+expression: result
+---
+"This should be a paragraph.\r\n\r\n> This should be a blockquote.\r\n> This should be in a previous blockquote.\r\n\r\n<div class=\"mdbook-alerts mdbook-alerts-note\">\r\n<p class=\"mdbook-alerts-title\">\r\n  <span class=\"mdbook-alerts-icon\"></span>\r\n  note\r\n</p>\r\n\r\n\r\nThis should be alert.\r\nThis should be in a previous alert.\r\n\r\n</div>\r\n\r\n\r\nThis should be a paragraph.\r\n"


### PR DESCRIPTION
Close #147 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of different line endings (Unix and Windows) when rendering alerts, ensuring consistent output regardless of the input format.

- **Tests**
  - Added new tests to verify alert rendering works correctly with both Unix (`\n`) and Windows (`\r\n`) line endings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->